### PR TITLE
Update Transalation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ git clone https://github.com/ethereum/solidity.git
 cd solidity
 ```
 
-pull the tags and checkout the latest version tag as a branch e.g. for v0.8.15:
+Remove all the tags. Only the tags with complete translation should exist in the language repo.
 ```
-git fetch --all --tags --prune
-git checkout tags/v0.8.15 -b v0.8.15 
+git tag | xargs git tag -d
 ```
+
 Mirror push the temporary local repository to the new repository
 ```
 git push --mirror git@github.com:solidity-docs/<language-code>.git

--- a/README.md
+++ b/README.md
@@ -41,11 +41,57 @@ For example:
 }
 ```
 
-Once the PR is accepted you will receive an invitation to join the solidity-docs GitHub organization.
+Once the PR is accepted we will create an empty repository with the [language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) followed by the English name of the language, e.g. for a German translation the repository would be called: ``de-german``. You will then be added as a maintainer to this repository. 
 
-As a next step, create a new repository in this organization. The name of the repository should consist of the [language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) followed by the English name of the language, e.g. for a German translation the repository would be called: ``de-german``. 
+As a next step, clone the Solidity repository locally:
+```
+git clone https://github.com/ethereum/solidity.git
+```
+```
+cd solidity
+```
 
-Then, go to the current Solidity repository and copy the [docs](https://github.com/ethereum/solidity/tree/develop/docs) folder content into your language repository.
+pull the tags and checkout the latest version tag as a branch e.g. for v0.8.15:
+```
+git fetch --all --tags --prune
+git checkout tags/v0.8.15 -b v0.8.15 
+```
+Mirror push the temporary local repository to the new repository
+```
+git push --mirror git@github.com:solidity-docs/<language-code>.git
+```
+
+Check if the repository is populated at https://github.com/solidity-docs/<language-code>
+
+Remove the temporary local repository:
+```
+cd ..
+rm -rf solidity
+```
+ 
+Clone the new repository
+```
+git clone git@github.com:solidity-docs/<language-code>.git
+```
+ 
+Remove all files except the `docs/` folder
+```
+cd <language-code>
+rm -vr !("docs")
+```
+ 
+Add a README
+```
+echo "# <title>" >> README.md
+```
+ 
+Push changes
+```
+git add .
+git commit -m "<commit message>"
+git push
+```
+ 
 
 That's it, now you can start translating! Make sure to create an issue with the [translations progress checklist](https://github.com/solidity-docs/translation-guide/blob/main/progress-checklist.md) in your repo to track the progress and please follow the recommendations outlined in the [maintainer guide](https://github.com/solidity-docs/translation-guide/blob/main/maintainer-guide.md).
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,14 @@ Remove all files except the `docs/` folder
 cd <language-code>
 rm -vr !("docs")
 ```
- 
+
+Remove all hidden files except `.git/`
+```
+mv .git git
+rm -r ./.*
+mv git .git
+```
+
 Add a README
 ```
 echo "# <title>" >> README.md

--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -18,7 +18,7 @@ As maintainers of one of the Solidity doc translations we ask you to please:
 Please do not change the names of the files and also keep the names of all tags and references. 
 
 There are some special Sphynx markup syntax to look for such as:
-- [References](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-arbitrary-locations): `.. _translations:` and :ref:_translations
+- [References](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-arbitrary-locations): `.. _translations:` and `:ref:_translations`
 - [Paragraph Level Markup](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#paragraph-level-markup): `.. note::` , `.. warning::`
 
 #### Glossary

--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -15,7 +15,11 @@ As maintainers of one of the Solidity doc translations we ask you to please:
 ### Tips
 
 #### File, Tags and Reference Names
-Please do not change the names of the files and also keep the names of all tags and references.
+Please do not change the names of the files and also keep the names of all tags and references. 
+
+There are some special Sphynx markup syntax to look for such as:
+- [References](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-arbitrary-locations): `.. _translations:` and :ref:_translations
+- [Paragraph Level Markup](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#paragraph-level-markup): `.. note::` , `.. warning::`
 
 #### Glossary
 Consider making a glossary of the translations of technical and Solidity-specific terms. Put this in a highly visible location (the README or a pinned issue).

--- a/maintainer-guide.md
+++ b/maintainer-guide.md
@@ -17,7 +17,7 @@ As maintainers of one of the Solidity doc translations we ask you to please:
 #### File, Tags and Reference Names
 Please do not change the names of the files and also keep the names of all tags and references. 
 
-There are some special Sphynx markup syntax to look for such as:
+There are some special [Sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html) markup syntax to look for such as:
 - [References](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#cross-referencing-arbitrary-locations): `.. _translations:` and `:ref:_translations`
 - [Paragraph Level Markup](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#paragraph-level-markup): `.. note::` , `.. warning::`
 


### PR DESCRIPTION
Update the instructions to start a language translation. 

- Maintainers are not added to the solidity-docs repo but added to the specific language repo. Update accordingly
- Add instructions to copy the solidity repo, remove tags, remove all files except docs, and push to the new language repo
- Add explicit warning to not translate Sphinx references and paragraph level markups (Infor, Warning, Notice etc.). 
  - Flaw: Paragraph level markups will stay in English but will be styled according to the notice level (e.g. red if Warning). 