### PR TITLE
Make translation bot configurable by translators

### DIFF
--- a/.github/workflows/create-daily-docs-sync-pr.yaml
+++ b/.github/workflows/create-daily-docs-sync-pr.yaml
@@ -10,8 +10,6 @@ env:
   BOT_USERNAME: soldocsbot
   BOT_EMAIL: solidity-docs-translations@ethereum.org
   GITHUB_REPOSITORY_OWNER: solidity-docs
-  # comma separated list of labels
-  LABELS: sync,automated-pr
 
 jobs:
   createPullRequest:
@@ -53,24 +51,35 @@ jobs:
           repository: ${{ github.repository }}
           path: .github-workflow
 
+      - name: Load bot configuration from translation-bot.json in the translation repository
+        id: bot-config
+        run: |
+          .github-workflow/scripts/load-translation-bot-config.sh translation-bot.json
+
       - name: Prepare pull request content
         id: prepare-pr
+        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}
         run: |
           .github-workflow/scripts/merge-conflicts.sh "$BOT_USERNAME" "$BOT_EMAIL"
           .github-workflow/scripts/generate-pr-body.sh
-          .github-workflow/scripts/set-assignees.sh "${{ matrix.repos }}"
+
+          if [[ ${{ steps.bot-config.outputs.randomly_assign_maintainers }} == true ]]; then
+            .github-workflow/scripts/set-assignees.sh "${{ matrix.repos }}"
+          fi
 
       - name: Commit pull request content
+        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}
         run: |
           # Needs to be in a separate step to access env.pr_title.
           git commit -m "${{ env.pr_title }}"
 
       - name: Remove this repository
+        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}
         run: |
           rm -rf .github-workflow
 
       - name: Create Pull Request
-        if: ${{ steps.prepare-pr.outputs.branch_exists == 'false' }}
+        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' && steps.prepare-pr.outputs.branch_exists == 'false' }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: "${{ secrets.PAT }}"
@@ -80,6 +89,6 @@ jobs:
           branch: "${{ steps.prepare-pr.outputs.branch_name }}"
           title: "${{ env.pr_title }}"
           body: "${{ env.pr_body }}"
-          labels: "${{ env.LABELS }}"
+          labels: "${{ join(fromJSON(steps.bot-config.outputs.pr_labels)) }}"
           assignees: ${{ env.assignee }}
           reviewers: ${{ env.reviewer }}

--- a/README.md
+++ b/README.md
@@ -116,10 +116,9 @@ If the file is not present, the bot uses the following default configuration:
 ```json
 {
     "disabled": false,
-    "randomly_assign_maintainers": true,
+    "randomly_assign_maintainers": false,
     "pr_labels": [
-        "sync",
-        "automated-pr"
+        "sync-pr"
     ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -109,6 +109,32 @@ Once your translations is advanced and you have checked the first part of the [t
 To help translators keep up with changes in the official documentation, which gets constantly expanded and updated, we run a translation bot.
 The bot regularly checks the main Solidity repository for changes and notifies translators by creating pull requests that indicate which parts require new translation.
 
+#### Bot Configuration
+Some aspects of the bot can be controlled via a file called `translation-bot.json` that can be placed in the root directory of a translation repository.
+If the file is not present, the bot uses the following default configuration:
+
+```json
+{
+    "disabled": false,
+    "randomly_assign_maintainers": true,
+    "pr_labels": [
+        "sync",
+        "automated-pr"
+    ]
+}
+```
+- `disabled` can be set to `true` to tell the bot that the maintainers of the repository do not want to receive sync PRs.
+    This is useful for example when the translators are targetting an older version of the documentation and would close these PRs anyway.
+- `randomly_assign_maintainers` makes the bot automatically assign maintainers and add reviewers to the PR.
+    Users are randomly chosen from the `maintainers` array in [the JSON file corresponding to their repository](https://github.com/solidity-docs/translation-guide/tree/main/langs).
+- `pr_labels` is a list of labels applied by the bot to sync PRs.
+    These are useful as a way to easily select all sync PRs on Github's PR list.
+
+When editing configuration please make sure it has no JSON syntax errors.
+Errors in the configuration file will prevent the bot from submitting PRs in your repository.
+In case of problems please check if there are any failures on [the list of bot runs](https://github.com/solidity-docs/translation-guide/actions/workflows/create-daily-docs-sync-pr.yaml).
+You can always ask for help in the [Solidity Docs Community Translations](https://app.element.io/#/room/#solidity-docs-translations:matrix.org) room on Matrix or, if you think it's a bug, please [report an issue](https://github.com/solidity-docs/translation-guide/issues).
+
 ### Acknowledgements
 
 Big kudos go out to the [ReactJS translations team repository](https://github.com/reactjs/reactjs.org-translation) and the [ethereum.org translation team](https://ethereum.org/en/contributing/translation-program/), which both inspired us with their resources and advised on setting up this process.

--- a/scripts/load-translation-bot-config.sh
+++ b/scripts/load-translation-bot-config.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_FILE="$1"
+
+function load_option {
+    local option="$1"
+    local default="$2"
+
+    if [[ ! -e $CONFIG_FILE ]]; then
+        echo "$default"
+        return 0
+    fi
+
+    # We want single-line output to be able to easily pass it to ::set-output
+    local value
+    value=$(jq --compact-output ".${option}" "$CONFIG_FILE")
+
+    if [[ $value == null ]]; then
+        echo "$default"
+    else
+        echo "$value"
+    fi
+}
+
+function validate_boolean {
+    local option="$1"
+    local value="$2"
+
+    if [[ $value != true && $value != false ]]; then
+        >&2 echo "${CONFIG_FILE}: Invalid option value for '${option}'. Expected 'true' or 'false', got '${value}'."
+        return 1
+    fi
+}
+
+function validate_list {
+    local option="$1"
+    local value="$2"
+
+    if ! echo "$value" | jq > /dev/null 2>&1; then
+        >&2 echo "${CONFIG_FILE}: Invalid option value for '${option}'. Expected a JSON list, got '${value}'."
+        return 1
+    fi
+}
+
+function print_option {
+    local option="$1"
+    local value="$2"
+
+    # The second echo is there so that we can actually see the value in the log for debug purposes
+    echo "::set-output name=${option}::${value}"
+    echo "${option}: ${value}"
+}
+
+# NOTE: If you change defaults here, remember to update the README
+bot_disabled=$(load_option disabled false)
+randomly_assign_maintainers=$(load_option randomly_assign_maintainers false)
+pr_labels=$(load_option pr_labels '["sync", "automated-pr"]')
+
+validate_boolean disabled "$bot_disabled"
+validate_boolean randomly_assign_maintainers "$randomly_assign_maintainers"
+validate_list pr_labels "$pr_labels"
+
+print_option bot_disabled "$bot_disabled"
+print_option randomly_assign_maintainers "$randomly_assign_maintainers"
+print_option pr_labels "$pr_labels"

--- a/scripts/load-translation-bot-config.sh
+++ b/scripts/load-translation-bot-config.sh
@@ -55,7 +55,7 @@ function print_option {
 # NOTE: If you change defaults here, remember to update the README
 bot_disabled=$(load_option disabled false)
 randomly_assign_maintainers=$(load_option randomly_assign_maintainers false)
-pr_labels=$(load_option pr_labels '["sync", "automated-pr"]')
+pr_labels=$(load_option pr_labels '["sync-pr"]')
 
 validate_boolean disabled "$bot_disabled"
 validate_boolean randomly_assign_maintainers "$randomly_assign_maintainers"


### PR DESCRIPTION
This PR allows translators to configure some aspects of the bot via a `translation-bot.json` file in the root of a translation repository. The bot can now be disabled, default labels can be changed and the feature that assigns random maintainers to the PR can be disabled too.

I'm also changing the default config:
- Disabling the random assignment of reviewers by default. Does not seem to be that useful in practice but the translators will still be able to enabled it in their repositories.
- Only one label on PRs. I don't think we really need two.
