### PR TITLE
Make sync PRs not lose history when there are no changes outside of `docs/`

### DIFF
--- a/scripts/merge-conflicts.sh
+++ b/scripts/merge-conflicts.sh
@@ -47,7 +47,11 @@ git add docs/
 # We need this for files outside of docs/ that happen to match the path of some file that exists
 # in the main repo, for example README.md or .gitignore. We do not copy these when setting up a
 # translation repo but to git they look like files from the main repo that need to be synced.
-git ls-files --modified --deleted | xargs git checkout --
+files_to_reset=$(git ls-files --modified --deleted)
+if [[ $files_to_reset != "" ]]; then
+    # NOTE: If the file list passed to `git checkout` is empty, git aborts the merge. We don't want that.
+    git ls-files --modified --deleted | xargs git checkout --
+fi
 
 # All the other files from the original merge commit are now untracked. We don't want them in the PR.
 git clean -d --force


### PR DESCRIPTION
While working on a sync PR for the Japanese repo, I noticed that locally the script was not creating a proper merge commit for me. Turns out that's a small bug in the script that happens when there are no files modified outside of `docs/` that the merge script would have to clear.

It's because  `git checkout --` when called without any files just resets the merge.