### PR TITLE
Preserve `CMakeLists.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,29 +77,22 @@ Clone the new repository
 git clone git@github.com:solidity-docs/<language-code>.git
 ```
 
-Remove all files except the `docs/` folder
+Remove files irrelevant to the translation
 ```
 cd <language-code>
-rm -vr !("docs")
-```
-
-Remove all hidden files except `.git/`
-```
-mv .git git
-rm -r ./.*
-mv git .git
+find . -mindepth 1 -maxdepth 1 ! \( -name "docs" -o -name "CMakeLists.txt" -o -name ".git" \) -exec git rm -r {} \;
 ```
 
 Add a README
 ```
 echo "# <title>" >> README.md
+git add README.md
+git commit -m "Prepare the repository for translation"
 ```
 
 Push changes
 ```
-git add .
-git commit -m "<commit message>"
-git push
+git push origin
 ```
 
 

--- a/scripts/merge-conflicts.sh
+++ b/scripts/merge-conflicts.sh
@@ -40,8 +40,9 @@ git pull english develop --rebase=false || true
 # This also "resolves" conflicts by keeping conflicted files as is including the conflict markers.
 git reset .
 
-# The only changes from the main repo that we're interested in are thos in docs/. Stage them.
-git add docs/
+# The only changes from the main repo that we're interested in are those in docs/ and
+# CMakeLists.txt, which is parsed by our Sphinx config to determine version. Stage them.
+git add docs/ CMakeLists.txt
 
 # Reset any files seen by git as modified/deleted to the state from before the merge.
 # We need this for files outside of docs/ that happen to match the path of some file that exists


### PR DESCRIPTION
Currently the bot does not synchronize `CMakeLists.txt` and the the initial repo setup instructions do not mention preserving this file. This means that the `docs/docs.sh` script will fail trying to extract compiler version from that file. This PR fixes that problem.