### PR TITLE
Enable the bot for Persian and Turkish

### DIFF
--- a/.github/workflows/create-daily-docs-sync-pr.yaml
+++ b/.github/workflows/create-daily-docs-sync-pr.yaml
@@ -26,13 +26,13 @@ jobs:
         repos:
           - de-german
           - es-spanish
-          #-fa-persian
+          - fa-persian
           - fr-french
           - ja-japanese
           - ko-korean
           - pt-portuguese
           - ru-russian
-          #-tr-turkish     # Disabled until translation of 0.8.15 is finished
+          - tr-turkish
           - zh-chinese
     steps:
       - name: Fetch translation repository


### PR DESCRIPTION
**Depends on https://github.com/solidity-docs/tr-turkish/pull/64. Please do not merge before that PR is merged.**

With the config added in https://github.com/solidity-docs/tr-turkish/pull/64 the bot still won't be submitting sync PRs in the Turkish repo but now without us having to hard-code that.