### PR TITLE
Make translation bot not fail when the sync PR has no conflicts

### DIFF
--- a/.github/workflows/create-daily-docs-sync-pr.yaml
+++ b/.github/workflows/create-daily-docs-sync-pr.yaml
@@ -71,7 +71,13 @@ jobs:
         if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}
         run: |
           # Needs to be in a separate step to access env.pr_title.
-          git commit -m "${{ env.pr_title }}"
+          if [[ $(git status --porcelain) != "" ]]; then
+            git commit -m "${{ env.pr_title }}"
+          else
+            # If there are no uncommitted changes, merge must have gone without conflicts.
+            # In that case just adjust the commit description.
+            git commit --amend -m "${{ env.pr_title }}"
+          fi
 
       - name: Remove this repository
         if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}


### PR DESCRIPTION
This PR fixes github action failures we've been seeing recently (e.g. [7758648721](https://github.com/solidity-docs/translation-guide/runs/7758648721)). They happen when the bot tries to commit the changes after resolving conflicts. If there were no conflicts, the commit already exists, there's nothing new to commit and git complains:

```
nothing added to commit but untracked files present (use "git add" to track)
Error: Process completed with exit code 1.
```
The solution is to skip the commit. We only need to adjust the message on an already existing commit.