### PR TITLE
Manual sync script

### DIFF
--- a/.github/workflows/create-daily-docs-sync-pr.yaml
+++ b/.github/workflows/create-daily-docs-sync-pr.yaml
@@ -101,7 +101,7 @@ jobs:
 
           # NOTE: The script will end up not creating a merge commit if there are no new upstream changes.
           # In that case we expect that the PR action will simply not create a PR.
-          ../bot/scripts/pull-and-resolve-english-changes.sh develop "$pr_title"
+          ../bot/scripts/pull-and-resolve-english-changes.sh english/develop "$pr_title"
 
           if [[ ${{ steps.bot-config.outputs.randomly_assign_maintainers }} == 'true' ]]; then
             ../bot/scripts/set-assignees.sh "${{ matrix.repos }}"

--- a/scripts/create-sync-branch-for-release.sh
+++ b/scripts/create-sync-branch-for-release.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script creates sync branches matching tagged releases in the main Solidity repository.
+# The result is a sync commit and a branch. The script does NOT push the branch or create a PR.
+
+# ASSUMPTIONS:
+# - The current directory already contains a clone of the translation repository.
+# - If a remote called 'english' exists, it points to the main Solidity repository.
+
+script_dir="$(dirname "$0")"
+
+function fail { >&2 echo -e "ERROR: $1"; exit 1; }
+
+(( $# == 1 )) || fail "Wrong number of arguments\nUsage: $0 <release tag>"
+TAG="$1"
+if ! git config remote.english.url; then
+    git remote add english "https://github.com/ethereum/solidity.git"
+fi
+
+git fetch english tag "$TAG" --no-tags
+git fetch english develop
+
+git checkout origin/develop
+git checkout -b "sync-${TAG}"
+
+today=$(date -u +%Y-%m-%d)
+"${script_dir}/pull-and-resolve-english-changes.sh" "$TAG" "Sync with ethereum/solidity@${TAG} (${today})"

--- a/scripts/pull-and-resolve-english-changes.sh
+++ b/scripts/pull-and-resolve-english-changes.sh
@@ -18,7 +18,7 @@ COMMIT_MESSAGE="$2"
 # We want to include the conflict markers as a part of the merge commit so that they're easy to spot in the PR.
 # The command will also fail if in the main repo there were modifications to files outside
 # of docs/ (these files are deleted in translation repos). These are the conflicts we want to ignore.
-if ! git merge "english/${SOLIDITY_REF}" -m "$COMMIT_MESSAGE"; then
+if ! git merge "${SOLIDITY_REF}" -m "$COMMIT_MESSAGE"; then
     # Unstage everything without aborting the merge.
     # This also "resolves" conflicts by keeping conflicted files as is including the conflict markers.
     git reset .


### PR DESCRIPTION
Depends on #42.

This PR adds a script for manually creating sync PRs with specific versions.

~Also refactors existing scripts to reuse the same conflict resolution logic.~ This actually went into #41.

I tested the updated code on the German repo and it successfully created a sync PR (https://github.com/solidity-docs/de-german/pull/84) so hopefully it does not introduce any problems.