### PR TITLE
Replace deprecated set-output with writing to $GITHUB_OUTPUT

### DIFF
--- a/scripts/load-translation-bot-config.sh
+++ b/scripts/load-translation-bot-config.sh
@@ -12,7 +12,7 @@ function load_option {
         return 0
     fi
 
-    # We want single-line output to be able to easily pass it to ::set-output
+    # We want single-line output to be able to easily pass it to $GITHUB_OUTPUT
     local value
     value=$(jq --compact-output ".${option}" "$CONFIG_FILE")
 
@@ -48,7 +48,7 @@ function print_option {
     local value="$2"
 
     # The second echo is there so that we can actually see the value in the log for debug purposes
-    echo "::set-output name=${option}::${value}"
+    echo "${option}=${value}" >> "$GITHUB_OUTPUT"
     echo "${option}: ${value}"
 }
 

--- a/scripts/merge-conflicts.sh
+++ b/scripts/merge-conflicts.sh
@@ -15,7 +15,7 @@ git fetch english --quiet
 sync_branch="sync-$(git describe --tags --always english/develop)"
 
 # pass the hash and the branch name to action "create PR"
-echo "::set-output name=branch_name::$sync_branch"
+echo "branch_name=$sync_branch" >> "$GITHUB_OUTPUT"
 
 # check if sync branch exists
 if git ls-remote --exit-code --heads origin "$sync_branch"
@@ -27,7 +27,7 @@ else
     echo "sync_branch $sync_branch does not exist"
 fi
 
-echo "::set-output name=branch_exists::$branch_exists"
+echo "branch_exists=$branch_exists" >> "$GITHUB_OUTPUT"
 
 # Try to pull changes from the main repository. Anything changed at the same time in the translation
 # and in the main repo will result in a conflict and will make the command fail. This is fine.


### PR DESCRIPTION
Apparently `set-output` is deprecated and Github will no longer be available after 2023-05-31: [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). This PR replaces all uses with the recommended alternative syntax.
