### PR TITLE
Fix for conflicting translation repo tags

### DIFF
--- a/.github/workflows/create-daily-docs-sync-pr.yaml
+++ b/.github/workflows/create-daily-docs-sync-pr.yaml
@@ -71,9 +71,17 @@ jobs:
           cd solidity/
           ../bot/scripts/generate-pr-body.sh
 
-      - name: Prepare pull request content
-        id: prepare-pr
+      - name: Check if sync branch already exists
+        id: check-sync-branch
         if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}
+        run: |
+          cd solidity/
+          sync_branch="sync-$(git describe --tags --always "english/develop")"
+          .github-workflow/scripts/check-remote-branch.sh "$sync_branch"
+          echo "branch_name=$sync_branch" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare pull request content
+        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' && steps.check-sync-branch.outputs.branch_exists == 'false' }}
         run: |
           cd solidity/
 
@@ -86,12 +94,12 @@ jobs:
           fi
 
       - name: Remove this repository
-        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}
+        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' && steps.check-sync-branch.outputs.branch_exists == 'false' }}
         run: |
           rm -rf bot/
 
       - name: Create Pull Request
-        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' && steps.prepare-pr.outputs.branch_exists == 'false' }}
+        if: ${{ steps.bot-config.outputs.bot_disabled == 'false' && steps.check-sync-branch.outputs.branch_exists == 'false' }}
         uses: peter-evans/create-pull-request@v3
         with:
           path: solidity/
@@ -99,7 +107,7 @@ jobs:
           commit-message: "${{ env.pr_title }}"
           committer: "${{ env.BOT_USERNAME }} <${{ env.BOT_EMAIL }}>"
           author: "${{ env.BOT_USERNAME }} <${{ env.BOT_EMAIL }}>"
-          branch: "${{ steps.prepare-pr.outputs.branch_name }}"
+          branch: "${{ steps.check-sync-branch.outputs.branch_name }}"
           title: "${{ env.pr_title }}"
           body: "${{ env.pr_body }}"
           labels: "${{ join(fromJSON(steps.bot-config.outputs.pr_labels)) }}"

--- a/.github/workflows/create-daily-docs-sync-pr.yaml
+++ b/.github/workflows/create-daily-docs-sync-pr.yaml
@@ -43,15 +43,25 @@ jobs:
           # By default, checkout is fetching only the last commit. This will
           # cause "unrelated histories" error. "0" means unlimited fetch-depth.
           fetch-depth: 0
-          path: solidity/
+          # This is the working copy we'll prepare the sync PR in.
+          path: translation/
 
       - name: Configure translation repository
         run: |
-          cd solidity/
+          cd translation/
           git config user.name "$BOT_USERNAME"
           git config user.email "$BOT_EMAIL"
           git remote add english "https://github.com/ethereum/solidity.git"
-          git fetch english develop --tags --quiet
+          git fetch english develop
+
+      - name: Fetch main Solidity repository
+        uses: actions/checkout@v2
+        with:
+          repository: ethereum/solidity
+          fetch-depth: 0
+          # This is the checkout where we can safely fetch the tags from the main Soldity repo and use git describe.
+          # Translation repositories have their own version tags that conflict with the ones in the main repo.
+          path: solidity/
 
       - name: Fetch bot's repository
         uses: actions/checkout@v2
@@ -63,11 +73,12 @@ jobs:
       - name: Load bot configuration from translation-bot.json in the translation repository
         id: bot-config
         run: |
-          bot/scripts/load-translation-bot-config.sh solidity/translation-bot.json
+          bot/scripts/load-translation-bot-config.sh translation/translation-bot.json
 
       - name: Prepare pull request title and description
         if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}
         run: |
+          # Use the main repository checkout with tags to get them in `git describe` output.
           cd solidity/
           ../bot/scripts/generate-pr-body.sh
 
@@ -75,15 +86,18 @@ jobs:
         id: check-sync-branch
         if: ${{ steps.bot-config.outputs.bot_disabled == 'false' }}
         run: |
-          cd solidity/
-          sync_branch="sync-$(git describe --tags --always "english/develop")"
-          .github-workflow/scripts/check-remote-branch.sh "$sync_branch"
+          pushd solidity/
+          sync_branch="sync-$(git describe --tags --always develop)"
           echo "branch_name=$sync_branch" >> "$GITHUB_OUTPUT"
+          popd
+
+          cd translation/
+          ../bot/scripts/check-remote-branch.sh "$sync_branch"
 
       - name: Prepare pull request content
         if: ${{ steps.bot-config.outputs.bot_disabled == 'false' && steps.check-sync-branch.outputs.branch_exists == 'false' }}
         run: |
-          cd solidity/
+          cd translation/
 
           # NOTE: The script will end up not creating a merge commit if there are no new upstream changes.
           # In that case we expect that the PR action will simply not create a PR.
@@ -102,7 +116,7 @@ jobs:
         if: ${{ steps.bot-config.outputs.bot_disabled == 'false' && steps.check-sync-branch.outputs.branch_exists == 'false' }}
         uses: peter-evans/create-pull-request@v3
         with:
-          path: solidity/
+          path: translation/
           token: "${{ secrets.PAT }}"
           commit-message: "${{ env.pr_title }}"
           committer: "${{ env.BOT_USERNAME }} <${{ env.BOT_EMAIL }}>"

--- a/scripts/check-remote-branch.sh
+++ b/scripts/check-remote-branch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+function fail { >&2 echo -e "ERROR: $1"; exit 1; }
+
+(( $# == 1 )) || fail "Wrong number of arguments\nUsage: $0 <translation repo branch"
+BRANCH="$1"
+
+# check if branch exists
+if git ls-remote --exit-code --heads origin "$BRANCH"
+then
+    branch_exists=true
+    echo "Branch ${BRANCH} already exists"
+else
+    branch_exists=false
+    echo "Branch ${BRANCH} does not exist"
+fi
+
+echo "branch_exists=$branch_exists" >> "$GITHUB_OUTPUT"

--- a/scripts/generate-pr-body.sh
+++ b/scripts/generate-pr-body.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 function modified_file_list {
-    commit_hash=$(git rev-parse --verify english/develop)
+    commit_hash=$(git rev-parse --verify develop)
     git status --short |
         grep "docs" |
         awk '{print "- [ ] ["$2"](https://github.com/ethereum/solidity/tree/'"${commit_hash}"'/"$2")"}'
@@ -13,12 +13,12 @@ function today_utc {
 }
 
 function sync_commit_human_readable_id {
-    git describe --tags --always english/develop
+    git describe --tags --always develop
 }
 
 function sync_commit_link {
     local commit_hash truncated_commit_hash
-    commit_hash=$(git rev-parse --verify english/develop)
+    commit_hash=$(git rev-parse --verify develop)
     truncated_commit_hash=$(echo "$commit_hash" | head -c 8)
 
     echo "[${truncated_commit_hash}](https://github.com/ethereum/solidity/tree/${commit_hash})"

--- a/scripts/pull-and-resolve-english-changes.sh
+++ b/scripts/pull-and-resolve-english-changes.sh
@@ -13,23 +13,6 @@ COMMIT_MESSAGE="$2"
 # - Remote 'english' exists and points at the main Solidity repository.
 # - Working copy is clean, with no modified or untracked files.
 
-sync_branch="sync-$(git describe --tags --always "english/${SOLIDITY_REF}")"
-
-# pass the hash and the branch name to action "create PR"
-echo "branch_name=$sync_branch" >> "$GITHUB_OUTPUT"
-
-# check if sync branch exists
-if git ls-remote --exit-code --heads origin "$sync_branch"
-then
-    branch_exists=true
-    echo "sync_branch $sync_branch exists"
-else
-    branch_exists=false
-    echo "sync_branch $sync_branch does not exist"
-fi
-
-echo "branch_exists=$branch_exists" >> "$GITHUB_OUTPUT"
-
 # Try to merge changes from the main repository. Anything changed at the same time in the translation
 # and in the main repo will result in a conflict and will make the command fail. This is fine.
 # We want to include the conflict markers as a part of the merge commit so that they're easy to spot in the PR.

--- a/scripts/pull-and-resolve-english-changes.sh
+++ b/scripts/pull-and-resolve-english-changes.sh
@@ -13,7 +13,7 @@ COMMIT_MESSAGE="$2"
 # - Remote 'english' exists and points at the main Solidity repository.
 # - Working copy is clean, with no modified or untracked files.
 
-sync_branch="sync-$(git describe --tags --always english/develop)"
+sync_branch="sync-$(git describe --tags --always "english/${SOLIDITY_REF}")"
 
 # pass the hash and the branch name to action "create PR"
 echo "branch_name=$sync_branch" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
After my previous fix for the daily run failures (#41) it's failing for yet another reason. This time it's because we started tagging translations and now these tags conflict with tags in the main repo when doing `git fetch --tags`.

```bash
git fetch english develop --tags
```
```
From https://github.com/ethereum/solidity
 * branch                develop    -> FETCH_HEAD
 ! [rejected]            v0.8.11    -> v0.8.11  (would clobber existing tag)
```

For example in [6360425941](https://github.com/solidity-docs/.github/actions/runs/3745717681/jobs/6360425941), the bot failed for this reason in the French repo. Note that the above output is not present in the log because we were passing `--quiet` to the the `git fetch` command so it would return an error code but not say why. I had to check that locally.

This PR changes the bot to use a separate checkout of the main repository when fetching tags. This prevents conflicts.
- I'm also pulling a branch check refactor from #39 because it makes the fix easier by separating branch checks (which need tags) from creating the sync branch (which needs branches from translation and upstream but not tags).
- I also fixed a tiny bug from #41 - the script for creating the sync branch was ignoring the `$SOLIDITY_REF` parameter when creating branch name. This did not break anything though because until #39 is merged, the value is always set to `develop`.

The code was tested in [3749892069](https://github.com/solidity-docs/.github/actions/runs/3749892069), which successfully created https://github.com/solidity-docs/de-german/pull/95 even after I manually created a `v0.8.17` tag in the German repo.