### PR TITLE
Fix the random maintainer assignment check

### DIFF
--- a/.github/workflows/create-daily-docs-sync-pr.yaml
+++ b/.github/workflows/create-daily-docs-sync-pr.yaml
@@ -103,7 +103,7 @@ jobs:
           # In that case we expect that the PR action will simply not create a PR.
           ../bot/scripts/pull-and-resolve-english-changes.sh develop "$pr_title"
 
-          if [[ ${{ steps.bot-config.outputs.randomly_assign_maintainers }} == true ]]; then
+          if [[ ${{ steps.bot-config.outputs.randomly_assign_maintainers }} == 'true' ]]; then
             ../bot/scripts/set-assignees.sh "${{ matrix.repos }}"
           fi
 


### PR DESCRIPTION
Fixes the bug pointed out by @r0qs in https://github.com/solidity-docs/.github/pull/42#pullrequestreview-1230156134. "Boolean" values in Github Actions are actually strings rather than actual booleans.

This means that the `randomly_assign_maintainers` setting must have been broken and always disabled regardless of what was in the config.